### PR TITLE
Improved Wrapper to support status command in json format

### DIFF
--- a/src/Phinx/Wrapper/TextWrapper.php
+++ b/src/Phinx/Wrapper/TextWrapper.php
@@ -83,6 +83,9 @@ class TextWrapper
         if ($this->hasOption('parser')) {
             $command += ['-p' => $this->getOption('parser')];
         }
+        if ($this->hasOption('format')) {
+            $command += ['-f' => $this->getOption('format')];
+        }
 
         return $this->executeRun($command);
     }


### PR DESCRIPTION
With this simple PR we grant the TextWrapper `status` command the support for `json` output format 
for ease of use. 